### PR TITLE
Fix password hashing.

### DIFF
--- a/src/main/kotlin/org/kotatsu/util/String.kt
+++ b/src/main/kotlin/org/kotatsu/util/String.kt
@@ -1,8 +1,10 @@
 package org.kotatsu.util
 
+import java.math.BigInteger
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.MessageDigest
 
-fun String.md5(): String = MessageDigest.getInstance("MD5").digest(this.toByteArray(UTF_8)).decodeToString()
+fun String.md5(): String =
+	BigInteger(1, MessageDigest.getInstance("MD5").digest(this.toByteArray(UTF_8))).toString(16).padStart(32, '0')
 
 fun String.truncated(maxLength: Int): String = if (length > maxLength) take(maxLength) else this


### PR DESCRIPTION
MD5 digest was converted to utf8 string, where invalid characters were ignored. Create proper hex string of length 32 as defined in db table.