### PR TITLE
Explicitly set InnoDB, utf8mb4, and 0900 collation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Synchronization is needed to store your collection of favorites, history and cat
 > [!TIP]
 > You can find the entire list of environment variables in the .env.example file.
 
+Supported databases: 
+
+* MySQL: 8.4+
+* MariaDB: 11.7+ or 11.4.5+
+
 ### Docker
 
 #### Build image container:

--- a/src/main/kotlin/org/kotatsu/plugins/Database.kt
+++ b/src/main/kotlin/org/kotatsu/plugins/Database.kt
@@ -20,7 +20,7 @@ fun Application.configureDatabase() {
     }
 
     val config = HikariConfig().apply {
-        jdbcUrl = "jdbc:$dialect://$host:$port/$name"
+        jdbcUrl = "jdbc:$dialect://$host:$port/$name?useUnicode=true&characterEncoding=utf8mb4&connectionCollation=utf8mb4_0900_ai_ci"
         username = environment.config.property("database.user").getString()
         password = environment.config.property("database.password").getString()
         driverClassName = jdbcDriver

--- a/src/main/resources/db/migration/V6__convert_all_tables_to_innodb_utf8mb4_0900_ai_ci.sql
+++ b/src/main/resources/db/migration/V6__convert_all_tables_to_innodb_utf8mb4_0900_ai_ci.sql
@@ -1,0 +1,31 @@
+SET foreign_key_checks = 0;
+
+ALTER TABLE users
+    CONVERT TO CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ENGINE = InnoDB;
+
+ALTER TABLE manga
+    CONVERT TO CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ENGINE = InnoDB;
+
+ALTER TABLE tags
+    CONVERT TO CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ENGINE = InnoDB;
+
+ALTER TABLE manga_tags
+    CONVERT TO CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ENGINE = InnoDB;
+
+ALTER TABLE categories
+    CONVERT TO CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ENGINE = InnoDB;
+
+ALTER TABLE favourites
+    CONVERT TO CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ENGINE = InnoDB;
+
+ALTER TABLE history
+    CONVERT TO CHARSET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+    ENGINE = InnoDB;
+
+SET foreign_key_checks = 1;


### PR DESCRIPTION
BREAKING CHANGE: The syncserver now strictly requires MySQL 8.0+ or MariaDB 11.4.5+ / 11.7+ (due to the use of `utf8mb4_0900_ai_ci` collation as an alias to `utf8mb4_uca1400_nopad_ai_ci`). Older versions are no longer compatible.